### PR TITLE
fixup push/pr/lint config

### DIFF
--- a/.github/workflows/push-pr-lint.yml
+++ b/.github/workflows/push-pr-lint.yml
@@ -42,15 +42,15 @@ jobs:
         with:
            context: .
            push: false
-           tags: ghcr.io/metal-toolbox/fleet-rest-skeleton:latest
+           tags: ghcr.io/metal-toolbox/bomservice:latest
            file: Dockerfile
 
       - name: Scan image
         id: scan-image
         uses: anchore/scan-action@v3
         with:
-          image: ghcr.io/metal-toolbox/fleet-rest-skeleton:latest
-          acs-report-enable: true
+          image: ghcr.io/metal-toolbox/bomservice:latest
+          # XXX: this generates a warning => acs-report-enable: true
           # TODO(joel): Fail build once we migrate off CentOS.
           fail-build: false
 


### PR DESCRIPTION
change some hard-coded tokens so they reflect the correct repo name, even if we don't push that image anywhere.